### PR TITLE
Shell now working on Linux (Fixes #2)

### DIFF
--- a/src/SysBasic.pas
+++ b/src/SysBasic.pas
@@ -236,7 +236,7 @@ begin
   OldDir := GetCurrentDir;
   SetCurrentDir(Directory);
 {$IFDEF LINUX}
-//  Result := Shell(aCmdLine) = 0; TODO: doesn't work
+  Result := ExecuteProcess('/usr/bin/bash', [ '-c', 'cd "' + Directory + '"; ' + aCmdLine]) = 0;
 {$ELSE}
   Result := ExecuteProcess(aCmdLine, '') = 0;
 {$ENDIF}


### PR DESCRIPTION
ExecuteProcess works under Linux but needs a shell process to use a full command line.